### PR TITLE
Guard against sorting nil values

### DIFF
--- a/lib/sort_authority.rb
+++ b/lib/sort_authority.rb
@@ -5,4 +5,14 @@ module SortAuthority
   extend FFI::Library
   ffi_lib FFI::Compiler::Loader.find('strnatcmp')
   attach_function :strnatcmp, [:pointer, :pointer], :int
+
+  class StringExpected < StandardError
+    def initialize(value)
+      super("#{value.inspect} is not a string.")
+    end
+  end
+
+  def self.ensure_strings(enum)
+    enum.each { |val| raise StringExpected, val unless val.instance_of?(String) }
+  end
 end

--- a/lib/sort_authority/ext/enumerable.rb
+++ b/lib/sort_authority/ext/enumerable.rb
@@ -1,17 +1,21 @@
 module Enumerable
   def natural_sort
+    SortAuthority.ensure_strings(self)
     sort {|a, b| SortAuthority.strnatcmp(a, b) }
   end
 
   def natural_sort!
+    SortAuthority.ensure_strings(self)
     sort! {|a, b| SortAuthority.strnatcmp(a, b) }
   end
 
   def natural_sort_by(&block)
+    SortAuthority.ensure_strings(self.map {|val| block.call(val) })
     sort {|a, b| SortAuthority.strnatcmp(block.call(a), block.call(b)) }
   end
 
   def natural_sort_by!(&block)
+    SortAuthority.ensure_strings(self.map {|val| block.call(val) })
     sort! {|a, b| SortAuthority.strnatcmp(block.call(a), block.call(b)) }
   end
 end

--- a/test/benchmark_test.rb
+++ b/test/benchmark_test.rb
@@ -5,4 +5,9 @@ describe 'SortAuthority Benchmark' do
     ary = ['x1'] * n
     ary.natural_sort
   end
+
+  bench_performance_linear '#natural_sort_by' do |n|
+    ary = [OpenStruct.new(name: 'x1')] * n
+    ary.natural_sort_by(&:name)
+  end
 end

--- a/test/ext/enumerable_test.rb
+++ b/test/ext/enumerable_test.rb
@@ -1,6 +1,12 @@
 require 'test_helper'
 
 describe Enumerable do
+  it 'raises an exception for nil values' do
+    assert_raises(SortAuthority::StringExpected) do
+      [nil, 'a'].natural_sort
+    end
+  end
+
   it 'natural sorts' do
     assert_equal ['9m', '10m'], ['10m', '9m'].natural_sort
   end


### PR DESCRIPTION
strnatcmp.c expects strings, but this can result in a very ugly error if
the enumerable contains a nil. Let's raise an exception so that the
expectation that all values be strings is clearer.
